### PR TITLE
Drop largest message from buffer on Kafka::MessageSizeTooLarge exception.

### DIFF
--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -383,7 +383,16 @@ module Kafka
         end
 
         assign_partitions!
-        operation.execute
+        begin
+          operation.execute
+        rescue Kafka::MessageSizeTooLarge => e
+          @logger.error "Received unrecoverable error #{e.class}: #{e.message}"
+          @logger.info "Dropping largest message from buffer.  Current buffer size: #{@buffer.size}, bytesize: #{@buffer.bytesize}"
+          @buffer.clear_largest_message
+          @logger.info "Dropped largest message from buffer.  Current buffer size: #{@buffer.size}, bytesize: #{@buffer.bytesize}"
+          sleep @retry_backoff
+          retry
+        end
 
         if @required_acks.zero?
           # No response is returned by the brokers, so we can't know which messages


### PR DESCRIPTION
We can get into a bad unrecoverable state when we get a Kafka::MessageSizeTooLarge exception.

When we receive this exception, we remove the largest message from the buffer and simply retry.  Once retried, if the buffer is still too large, we'll continue removing the largest message until we can successfully flush the buffer.

I won't merge this PR into master.  I'll instead attempt to get this merged upstream.  Making this a PR for reference, so we can go through the code review process internally.